### PR TITLE
fix release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: release
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+([0-9]+)'
+      - 'v*.*.*'
 
 jobs:
   pypi-release:


### PR DESCRIPTION
GH actions uses globs instead of regex

